### PR TITLE
Added automatically resume unfinished game

### DIFF
--- a/GUI/GameEssentials.java
+++ b/GUI/GameEssentials.java
@@ -1,9 +1,9 @@
 package GUI;
 
 import GUI.animation.*;
-import Launcher.LaunchEssentials;
 import hex.HexEngine;
 import game.Queue;
+import hex.Piece;
 import hexio.HexLogger;
 import io.GameTime;
 
@@ -252,7 +252,8 @@ public final class GameEssentials {
         return half - (int)Math.round((engine.getRadius() * 1.5 + 2) * HexButton.getActiveSize());
     }
     // Initializing
-    public static void initialize(int size, int queueSize, int delay, boolean easy, JFrame frame, String player){
+    public static void initialize(int size, int queueSize, int delay, boolean easy, JFrame frame, String player, HexLogger logger){
+        System.out.println(GameTime.generateSimpleTime() + " GameEssentials: Game starts.");
         if(easy) {
             game.PieceFactory.setEasy();
         }
@@ -260,9 +261,27 @@ public final class GameEssentials {
         queue = new Queue(queueSize);
         window = frame;
         // Logger initialize
-        gameLogger = new HexLogger(LaunchEssentials.getCurrentPlayer(), LaunchEssentials.getCurrentPlayerID());
-        gameLogger.setEngine(engine);
-        gameLogger.setQueue(queue.getPieces());
+        gameLogger = logger;
+        if(logger.getEngine().getRadius() == size && logger.getQueue().length == queueSize){
+            // Copy logger info to game
+            for (hex.Block block : logger.getEngine().blocks()){
+                if (block != null && block.getState()) {
+                    engine.setState(block.getLineI(), block.getLineK(), true);
+                }
+            }
+            Piece[] loggerQueue = logger.getQueue();
+            for (int i = 0; i < loggerQueue.length; i++) {
+                Piece piece = loggerQueue[i];
+                if (piece != null) {
+                    piece.setColor(engine.getFilledBlockColor());
+                    queue.inject(piece, i);
+                }
+            }
+        } else {
+            // Copy info to logger
+            gameLogger.setEngine(engine);
+            gameLogger.setQueue(queue.getPieces());
+        }
         // Construct labels
         turnLabel = new GameInfoPanel();
         scoreLabel = new GameInfoPanel();
@@ -338,7 +357,7 @@ public final class GameEssentials {
         clickedOnIndex = -1;
         turnLabel.setInfo(turn + "");
         scoreLabel.setInfo(score + "");
-        gameLogger = new HexLogger(LaunchEssentials.getCurrentPlayer(), LaunchEssentials.getCurrentPlayerID());
+        gameLogger = new HexLogger(Launcher.LaunchEssentials.getCurrentPlayer(), Launcher.LaunchEssentials.getCurrentPlayerID());
         engine.reset();
         queue.reset();
         gameLogger.setEngine(engine);

--- a/Launcher/LaunchEssentials.java
+++ b/Launcher/LaunchEssentials.java
@@ -104,23 +104,23 @@ public final class LaunchEssentials {
         gameStarted = true;
         int delay = 250;
         if (currentGameInfo.getGameMode() == GameMode.Small){
-            GameEssentials.initialize(5, 3, delay, false, LauncherGUI.getMainFrame(), getCurrentPlayer());
+            GameEssentials.initialize(5, 3, delay, false, LauncherGUI.getMainFrame(), getCurrentPlayer(), smartCreateLogger(5, 3));
         } else if (currentGameInfo.getGameMode() == GameMode.Medium){
-            GameEssentials.initialize(8, 5, delay, false, LauncherGUI.getMainFrame(), getCurrentPlayer());
+            GameEssentials.initialize(8, 5, delay, false, LauncherGUI.getMainFrame(), getCurrentPlayer(), smartCreateLogger(8, 5));
         } else if (currentGameInfo.getGameMode() == GameMode.Large){
-            GameEssentials.initialize(11, 7, delay, false, LauncherGUI.getMainFrame(), getCurrentPlayer());
+            GameEssentials.initialize(11, 7, delay, false, LauncherGUI.getMainFrame(), getCurrentPlayer(), smartCreateLogger(11, 7));
         } else if (currentGameInfo.getGameMode() == GameMode.SmallEasy){
-            GameEssentials.initialize(5, 3, delay, true, LauncherGUI.getMainFrame(), getCurrentPlayer());
+            GameEssentials.initialize(5, 3, delay, true, LauncherGUI.getMainFrame(), getCurrentPlayer(), smartCreateLogger(5, 3));
         } else if (currentGameInfo.getGameMode() == GameMode.MediumEasy){
-            GameEssentials.initialize(8, 5, delay, true, LauncherGUI.getMainFrame(), getCurrentPlayer());
+            GameEssentials.initialize(8, 5, delay, true, LauncherGUI.getMainFrame(), getCurrentPlayer(), smartCreateLogger(8, 5));
         } else if (currentGameInfo.getGameMode() == GameMode.LargeEasy){
-            GameEssentials.initialize(11, 7, delay, true, LauncherGUI.getMainFrame(), getCurrentPlayer());
+            GameEssentials.initialize(11, 7, delay, true, LauncherGUI.getMainFrame(), getCurrentPlayer(), smartCreateLogger(11, 7));
         } else if(currentGameInfo.getGameMode() == GameMode.Unspecified){
-            System.err.println("Legacy GameMode.Unspecified GameMode unsupported since Version 0.4.1");
-            GameEssentials.initialize(5, 3, delay, false, LauncherGUI.getMainFrame(), getCurrentPlayer());
+            System.err.println(GameTime.generateSimpleTime() + " GameEssentials: Legacy GameMode.Unspecified GameMode unsupported since Version 0.4.1");
+            GameEssentials.initialize(5, 3, delay, false, LauncherGUI.getMainFrame(), getCurrentPlayer(), smartCreateLogger(5, 3));
         } else {
-            System.err.println("Unknown GameMode detected.");
-            GameEssentials.initialize(5, 3, delay, false, LauncherGUI.getMainFrame(), getCurrentPlayer());
+            System.err.println(GameTime.generateSimpleTime() + " GameEssentials: Unknown GameMode detected.");
+            GameEssentials.initialize(5, 3, delay, false, LauncherGUI.getMainFrame(), getCurrentPlayer(), smartCreateLogger(5, 3));
         }
     }
     public static void endGame(){
@@ -135,6 +135,25 @@ public final class LaunchEssentials {
     }
     public static long getCurrentPlayerID(){
         return currentGameInfo.getPlayerID();
+    }
+    public static hexio.HexLogger smartCreateLogger(int size, int queueSize){
+        hexio.HexLogger logger = new hexio.HexLogger(getCurrentPlayer(), getCurrentPlayerID()); // Default logger
+        java.util.ArrayList<hexio.HexLogger> loggers = hexio.HexLogger.generateJsonLoggers();
+        // Search for incomplete games
+        if(!loggers.isEmpty() && currentGameInfo.getPlayerID() != -1 && !currentGameInfo.getPlayer().equals("Guest")){
+            for (hexio.HexLogger generatedLogger : loggers){
+                try {
+                    generatedLogger.read();
+                } catch (IOException e) {continue;}
+                if (!generatedLogger.isCompleted() && generatedLogger.getEngine().getRadius() == size
+                        && generatedLogger.getQueue().length == queueSize
+                        && generatedLogger.getPlayerID() == currentGameInfo.getPlayerID()){
+                    System.out.println(GameTime.generateSimpleTime() + " HexLogger: Unfinished game found at file " + generatedLogger.getDataFileName() + ".");
+                    logger = generatedLogger;
+                }
+            }
+        }
+        return logger;
     }
     public static void initialize(){
         currentGameInfo = new GameInfo(GameMode.Small, currentGameVersion);

--- a/game/Queue.java
+++ b/game/Queue.java
@@ -194,8 +194,20 @@ public class Queue{
      */
     public String toString(){
         StringBuilder result = new StringBuilder("Queue[");
-        for (int i = 0; i < length(); i ++){
-            result.append(pieces[i].toString());
+        if (pieces.length > 0){
+            if (pieces[0] == null) {
+                result.append("null");
+            } else {
+                result.append(pieces[0]);
+            }
+        }
+        for (int i = 1; i < length(); i ++){
+            result.append(", ");
+            if (pieces[i] == null) {
+                result.append("null");
+            } else {
+                result.append(pieces[i]);
+            }
         }
         return result + "]";
     }

--- a/game/Queue.java
+++ b/game/Queue.java
@@ -84,6 +84,28 @@ public class Queue{
         }
     }
     /**
+     * Forcefully inject a {@link Piece} into a specific position in the queue.
+     * <p>
+     * If the piece is null or the index is out of bounds, the injection will be rejected and instead the queue will
+     * not change. The elements in the queue will not be shifted.
+     * <p>
+     * This operation is considered risky as it needs manual color generation and piece shape rule conforming.
+     * There is no guarantee that the piece would be a usual piece defined by the game.
+     * Use whenever necessary at your own risk.
+     * @return whether the injection is successful
+     * @since 1.2
+     */
+    public boolean inject(Piece piece, int index){
+        if(index == -1){
+            return inject(piece, pieces.length - 1);
+        } else if (piece == null || index >= pieces.length || index < -1){
+            return false; // Reject injection
+        } else {
+            pieces[index] = piece;
+            return true;
+        }
+    }
+    /**
      * Removes and returns the first {@link Piece} in the queue.
      * The remaining elements shift left by one, and a new {@code Piece} is generated and added to the end.
      * @return the first {@link Piece} in the queue.

--- a/hex/Block.java
+++ b/hex/Block.java
@@ -117,13 +117,21 @@ public class Block extends Hex{
 
     /**
      * String representation of the block used for debugging. This use line coordinates.
-     * <p>Format: {@code [color = {r, g, b}, coordinates = {i, j, k}, State = state]}</p>
+     * <p>Format: {@code Block[color = {r, g, b}, coordinates = {i, j, k}, State = state]}</p>
      * @return A string representation of the block, including color, coordinates, and state.
      */
     public String toString(){
         return "Block[color = {" + color.getRed() + ", " + color.getGreen() + ", " + color.getBlue()
                 + "}, coordinates = {" + getLineI() + ", " + getLineJ() + ", " + getLineK() +
                 "}, state = " + state + "]";
+    }
+    /**
+     * String representation of the block used for debugging with less information. This use line coordinates.
+     * <p>Format: {@code {i, j, k, state}}</p>
+     * @return A string representation of the block, including only coordinates and state.
+     */
+    public String toBasicString(){
+        return "{" + getLineI() + ", " + getLineJ() + ", " + getLineK() + ", " + state + "}";
     }
     /**
      * {@inheritDoc}

--- a/hex/Block.java
+++ b/hex/Block.java
@@ -116,15 +116,14 @@ public class Block extends Hex{
     }
 
     /**
-     * String representation of the block used for debugging
-     * <p>Format: {@code {Color = {r, g, b}; I,J,K = {i, j, k}; Line I,J,K = {i, j, k}; X,Y = {x, y}; State = state;}}</p>
+     * String representation of the block used for debugging. This use line coordinates.
+     * <p>Format: {@code [color = {r, g, b}, coordinates = {i, j, k}, State = state]}</p>
      * @return A string representation of the block, including color, coordinates, and state.
      */
     public String toString(){
-        return "{Color = {" + color.getRed() + ", " + color.getGreen() + ", " + color.getBlue()
-                + "}; I,J,K = {" + I() + ", " + J() + ", " + K() +
-                "}; Line I,J,K = {" + getLineI() + ", " + getLineJ() + ", " + getLineK() +
-                "}; X,Y = {" + X() + ", "+ Y() + "}; State = " + state + ";}";
+        return "Block[color = {" + color.getRed() + ", " + color.getGreen() + ", " + color.getBlue()
+                + "}, coordinates = {" + getLineI() + ", " + getLineJ() + ", " + getLineK() +
+                "}, state = " + state + "]";
     }
     /**
      * {@inheritDoc}

--- a/hex/Hex.java
+++ b/hex/Hex.java
@@ -416,13 +416,13 @@ public class Hex{
     }
     /**
      * String representation of the hex coordinate used for debugging
-     * <p>Format: {@code {hex I,J,K = {i, j, k}, Line I,J,K = {i, j, k}, Rect X,Y = {x, y}}}</p>
+     * <p>Format: {@code Hex[raw = {i, j, k}, line = {i, j, k}, rect = {x, y}]}</p>
      * @return A string representation of the hex coordinate, including its rectangular conversion.
      */
     public String toString(){
-        return "{hex I,J,K = {" + I() + ", " + J() + ", " + K() +
-                "}, Line I,J,K = {" + getLineI() + ", " + getLineJ() + ", " + getLineK() +
-                "}, Rect X,Y = {" + X() + ", "+ Y() + "}}";
+        return "Hex[raw = {" + I() + ", " + J() + ", " + K() +
+                "}, line = {" + getLineI() + ", " + getLineJ() + ", " + getLineK() +
+                "}, rect = {" + X() + ", "+ Y() + "}]";
     }
 
     // Coordinate manipulation

--- a/hex/HexEngine.java
+++ b/hex/HexEngine.java
@@ -559,19 +559,33 @@ public class HexEngine implements HexGrid{
 
 
     /**
-     * Returns a string representation of the grid and block states.
+     * Returns a string representation of the grid color and block states.
      * @return string showing block positions and states
      * @see Block#toString()
      */
     public String toString(){
-        StringBuilder str = new StringBuilder("{HexEngine: ");
-        for (Block block : blocks) {
-            str.append(block.getLines());
-            str.append(",");
-            str.append(block.getState());
-            str.append("; ");
+        StringBuilder str = new StringBuilder("HexEngine[empty = {");
+        str.append(emptyBlockColor.getRed());
+        str.append(", ");
+        str.append(emptyBlockColor.getGreen());
+        str.append(", ");
+        str.append(emptyBlockColor.getBlue());
+        str.append("}, filled = {");
+        str.append(filledBlockColor.getRed());
+        str.append(", ");
+        str.append(filledBlockColor.getGreen());
+        str.append(", ");
+        str.append(filledBlockColor.getBlue());
+        str.append("}, blocks = {");
+        if (blocks.length > 0){
+            str.append(blocks[0].toBasicString());
         }
-        return str + "}";
+        for (int i = 1; i < blocks.length; i++) {
+            Block block = blocks[i];
+            str.append(", ");
+            str.append(block.toBasicString());
+        }
+        return str + "}]";
     }
 
     /**

--- a/hex/Piece.java
+++ b/hex/Piece.java
@@ -253,9 +253,22 @@ public class Piece implements HexGrid{
      * @see Block#toString()
      */
     public String toString(){
-        StringBuilder str = new StringBuilder("{Piece: ");
-        for (Block block : blocks) {
-            str.append(block.getLines());
+        StringBuilder str = new StringBuilder("Piece{");
+        if (blocks.length > 0){
+            if (blocks[0] == null) {
+                str.append("null");
+            } else {
+                str.append(blocks[0].toBasicString());
+            }
+        }
+        for (int i = 1; i < blocks.length; i++) {
+            Block block = blocks[i];
+            str.append(", ");
+            if (block == null) {
+                str.append("null");
+            } else {
+                str.append(block.toBasicString());
+            }
         }
         return str + "}";
     }

--- a/hex/Piece.java
+++ b/hex/Piece.java
@@ -260,6 +260,32 @@ public class Piece implements HexGrid{
         return str + "}";
     }
     /**
+     * Returns a byte representation of the blocks in this {@code Piece}, if this piece confines
+     * to the standard of a 7-{@link Block} piece.
+     * <p>
+     * Empty blocks will be represented with 0s and filled blocks will be represented with 1s.
+     * This method does not record color.
+     * @return a byte representing this 7-block piece. The first bit is empty.
+     */
+    public byte toByte(){
+        byte mask = 0x7F;
+        byte data = 0;
+        if (getState(-1, -1)) data ++;
+        data = (byte) (data << 1);
+        if (getState(-1, 0)) data ++;
+        data = (byte) (data << 1);
+        if (getState(0, -1)) data ++;
+        data = (byte) (data << 1);
+        if (getState(0, 0)) data ++;
+        data = (byte) (data << 1);
+        if (getState(0, 1)) data ++;
+        data = (byte) (data << 1);
+        if (getState(1, 0)) data ++;
+        data = (byte) (data << 1);
+        if (getState(1, 1)) data ++;
+        return (byte) (data & mask);
+    }
+    /**
      * Compares this piece to another for equality.
      * Two pieces are equal if they have the same {@link #length()} and identical {@link Block} positions.
      * {@link Color} is not involved in this comparison.

--- a/hex/Piece.java
+++ b/hex/Piece.java
@@ -187,6 +187,19 @@ public class Piece implements HexGrid{
         }
         return null;
     }
+    /**
+     * Retrieves the state of a {@link Block} at the specified line coordinates. If the block does not exist,
+     * it is counted as empty
+     * @param i the I-line coordinate of the target block
+     * @param k the K-line coordinate of the target block
+     * @return the block at the specified {@link Hex} line coordinate
+     * @see #getBlock(int, int)
+     * @since 1.2
+     */
+    public boolean getState(int i, int k){
+        Block block = getBlock(i, k);
+        return block != null && block.getState();
+    }
     /**{@inheritDoc}*/
     public Block getBlock(int index){
         return blocks[index];

--- a/hexio/HexConverter.java
+++ b/hexio/HexConverter.java
@@ -447,6 +447,25 @@ public final class HexConverter {
                 throw new IOException("Block array in \"Piece\" not found");
             }
         }
+        return convertPiece(jsonArray);
+    }
+    /**
+     * Converts a JSON array to a {@link Piece}.
+     * The JSON array must contain an array of valid blocks, with at least one block having a true state.
+     * The piece's color is derived from the first valid block.
+     * <p>
+     * This is the inverse method of {@link #convertPiece(Piece)}.
+     *
+     * @param jsonArray the JSON array containing the piece data
+     * @return a {@code Piece} object
+     * @throws IOException if the JSON array is null or contains no valid blocks
+     * @see Piece#Piece
+     * @see #convertPiece(JsonObject)
+     * @see #convertColor(JsonObject)
+     * @see #convertBlock(JsonObject)
+     */
+    public static Piece convertPiece(JsonArray jsonArray) throws IOException {
+        if (jsonArray == null) throw new IOException("\"Piece\" object is null or not found");
         // Check first real block exists, and try to get color
         int size = jsonArray.size();
         int valid = 0;
@@ -462,7 +481,7 @@ public final class HexConverter {
         }
         if (valid == 0) throw new IOException("\"Piece\" object does not contain valid blocks");
         // Create piece object
-        Piece piece = new Piece(jsonArray.size(), color);
+        Piece piece = new Piece(valid, color);
         for (int i = 0; i < size; i ++){
             try {
                 Block block = convertBlock(jsonArray.getJsonObject(i));

--- a/hexio/HexLogger.java
+++ b/hexio/HexLogger.java
@@ -485,5 +485,45 @@ public class HexLogger {
         } catch (Exception e) {
             throw new IOException("Fail to read game queue");
         }
+
+        // Read moves
+        try{
+            JsonArray movesJson = jsonObject.getJsonArray("moves");
+            int movesSize = movesJson.size();
+            // Populate moves
+            for (int i = 0; i < movesSize; i ++){
+                try {
+                    JsonObject moveJson = movesJson.getJsonObject(i);
+                    // Check move order
+                    int moveNumber = -1;
+                    try {
+                        moveNumber = moveJson.getInt("order");
+                    } catch (Exception e) {}
+                    if (moveNumber != i) {
+                        throw new IOException("Fail to read move at index " + i + " in game moves because move order does not match");
+                    }
+                    // Record move
+                    Hex moveOrigin; Piece movePiece;
+                    try {
+                        JsonObject moveOriginJson = movesJson.getJsonObject(i);
+                        moveOrigin = HexConverter.convertHex(moveOriginJson);
+                    } catch (Exception e) {
+                        throw new IOException("Fail to read move at index " + i + " in game moves due to failed center conversion");
+                    }
+                    try {
+                        JsonObject movePieceJson = movesJson.getJsonObject(i);
+                        movePiece = HexConverter.convertPiece(movePieceJson);
+                    } catch (Exception e) {
+                        throw new IOException("Fail to read move at index " + i + " in game moves due to failed piece conversion");
+                    }
+                    moveOrigins.add(moveOrigin);
+                    movePieces.add(movePiece);
+                } catch (Exception e) {
+                    throw new IOException("Fail to read move at index " + i + " in game moves");
+                }
+            }
+        } catch (Exception e) {
+            throw new IOException("Fail to read game moves");
+        }
     }
 }

--- a/hexio/HexLogger.java
+++ b/hexio/HexLogger.java
@@ -1,7 +1,6 @@
 package hexio;
 
 import hex.*;
-import io.*;
 
 import javax.json.*;
 import javax.json.stream.*;
@@ -462,6 +461,29 @@ public class HexLogger {
         }
 
         // Read engine
+        try{
+            JsonObject engineJson = jsonObject.getJsonObject("engine");
+            currentEngine = HexConverter.convertEngine(engineJson);
+        } catch (Exception e) {
+            throw new IOException("Fail to read game engine");
+        }
 
+        // Read queue
+        try{
+            JsonArray queueJson = jsonObject.getJsonArray("queue");
+            int queueSize = queueJson.size();
+            currentQueue = new Piece[queueSize];
+            // Populate queue
+            for (int i = 0; i < queueSize; i ++){
+                try {
+                    JsonObject pieceJson = queueJson.getJsonObject(i);
+                    currentQueue[i] = HexConverter.convertPiece(pieceJson);
+                } catch (Exception e) {
+                    throw new IOException("Fail to read piece at index " + i + " in game queue");
+                }
+            }
+        } catch (Exception e) {
+            throw new IOException("Fail to read game queue");
+        }
     }
 }

--- a/hexio/HexLogger.java
+++ b/hexio/HexLogger.java
@@ -232,6 +232,56 @@ public class HexLogger {
         }
         return success;
     }
+    /**
+     * Returns a String representation of the {@code HexLogger}, containing all its essential information.
+     * <p>
+     * This String representation contains the following elements:
+     * <ul>
+     *     <li>The path to the file that the logger is pointing to and operating for</li>
+     *     <li>The player of the recorded game and its ID</li>
+     *     <li>The complete status of the game contained in the logger and the file</li>
+     *     <li>The current {@link HexEngine} representing the recorded game field</li>
+     *     <li>The current {@link Piece} queue in the recorded game</li>
+     *     <li>The moves, containing centers {@link Hex} coordinates and {@link Piece} placed, in the recorded game</li>
+     * </ul>
+     * This method use the {@link Object#toString toString} method in the contained objects to generate string representations.
+     */
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("GameLogger[type = HexLogger, path = ");
+        builder.append(dataFile);
+        builder.append(", data = HexData[player = ");
+        builder.append(player);
+        builder.append(", playerID = ");
+        builder.append(playerID);
+        builder.append(", engine = ");
+        builder.append(currentEngine);
+        builder.append(", queue = {");
+        if (currentQueue.length > 0){
+            builder.append(currentQueue[0]);
+        }
+        for (int i = 1; i < currentQueue.length; i++) {
+            builder.append(", ");
+            builder.append(currentQueue[i]);
+        }
+        builder.append("}, moves = {");
+        if (!movePieces.isEmpty() && !moveOrigins.isEmpty()){
+            builder.append("HexMove[center = ");
+            builder.append(moveOrigins.get(0));
+            builder.append(", piece = ");
+            builder.append(movePieces.get(0));
+            builder.append("]");
+        }
+        for (int i = 1; i < moveOrigins.size(); i++) {
+            builder.append(", HexMove[center = ");
+            builder.append(moveOrigins.get(i));
+            builder.append(", piece = ");
+            builder.append(movePieces.get(i));
+            builder.append("]");
+        }
+        builder.append("}]]");
+        return builder.toString();
+    }
 
     // JSON
     /**

--- a/hexio/HexLogger.java
+++ b/hexio/HexLogger.java
@@ -14,6 +14,104 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.ArrayList;
 
+/**
+ * The {@code HexLogger} class is designed to log and manage game data for the "HappyHex" game,
+ * specifically handling the recording, storage, and retrieval of game state data in JSON format.
+ * It supports logging critical game elements such as the game engine, piece queue, and player moves,
+ * ensuring accurate tracking of game progress. The class also provides obfuscation mechanisms for
+ * generating unique identifiers and timestamps, enhancing data integrity and uniqueness.
+ *
+ * <h3>Purpose</h3>
+ * The primary purpose of {@code HexLogger} is to serve as a robust logging utility for the HappyHex game,
+ * enabling developers to save game states to JSON files, read them back, and manage game data efficiently.
+ * It is particularly useful for tracking player progress, debugging, and analyzing game sessions.
+ * The class supports the {@code hex.basic} and {@code hex} (unnamed) data formats, with plans to
+ * support additional formats in future releases.
+ *
+ * <h3>Function</h3>
+ * The {@code HexLogger} class provides the following key functionalities:
+ * <ul>
+ *     <li><b>Game State Logging:</b> Records the current state of the game, including the {@link HexEngine},
+ *         piece queue, and move history, into a JSON file with the {@code .hpyhex.json} extension.</li>
+ *     <li><b>Data Retrieval:</b> Reads and parses JSON log files to reconstruct game states in memory,
+ *         populating fields like the engine, queue, and moves.</li>
+ *     <li><b>Obfuscation:</b> Generates unique, obfuscated hashes and timestamps for filenames and identifiers
+ *         using bit-shifting and prime multiplication techniques to ensure uniqueness and security.</li>
+ *     <li><b>File Management:</b> Manages JSON files in the {@code /data/} directory, including creating,
+ *         reading, writing, and deleting game log files.</li>
+ *     <li><b>Player Management:</b> Tracks player information, including name and ID, with support for
+ *         guest profile for invalid or non-existent inputs.</li>
+ *     <li><b>Game Completion:</b> Marks games as completed to prevent further modifications, ensuring
+ *         data integrity for finalized game sessions.</li>
+ * </ul>
+ *
+ * <h3>Data Format</h3>
+ * This is version 1.2 of the {@code HexLogger} class, adhering to the {@code hex.basic} format standard.
+ * It currently supports reading and writing in the {@code hex.basic} and {@code hex} (unnamed) formats.
+ * Support for additional data formats is planned for future releases. See {@link #readHexData} for formats.
+ *
+ * <h3>Example Usage</h3>
+ * Below is an example demonstrating how to use the {@code HexLogger} class to log a game session,
+ * add moves, complete the game, and read the logged data:
+ *
+ * <pre>{@code
+ * // Initialize a HexLogger for a player
+ * HexLogger logger = new HexLogger("PlayerOne", 123456789L);
+ *
+ * // Set up the game engine and piece queue
+ * HexEngine engine = new HexEngine(1, java.awt.Color.BLACK, java.awt.Color.WHITE);
+ * logger.setEngine(engine);
+ * Piece[] queue = {piece, piece};
+ * logger.setQueue(queue);
+ *
+ * // Add a move
+ * Hex origin = new Hex(0, 0);
+ * boolean moveSuccess = logger.addMove(origin, piece);
+ * if (moveSuccess) {
+ *     System.out.println("Move added successfully.");
+ * }
+ *
+ * // Complete the game, lock data
+ * logger.completeGame();
+ *
+ * // Write the game data to a JSON file
+ * try {
+ *     logger.write();
+ *     System.out.println("Game data saved to: " + logger.getDataFileName());
+ * } catch (IOException e) {
+ *     System.err.println("Failed to save game data: " + e.getMessage());
+ * }
+ *
+ * // Read the game data from the JSON file
+ * HexLogger newLogger = new HexLogger(logger.getDataFileName());
+ * try {
+ *     newLogger.read();
+ *     System.out.println("Game data loaded: " + newLogger.toString());
+ * } catch (IOException e) {
+ *     System.err.println("Failed to load game data: " + e.getMessage());
+ * }
+ *
+ * // Delete the log file if no longer needed
+ * boolean deleted = logger.deleteFile();
+ * if (deleted) {
+ *     System.out.println("Log file deleted successfully.");
+ * }
+ * }</pre>
+ *
+ * <h3>Notes</h3>
+ * <ul>
+ *     <li>This class is dependent on {@link hex} package and its JSON conversion class {@link HexConverter}.</li>
+ *     <li>Files are stored in the {@code /data/} directory with names {@link #generateFileName generated} using
+ *         obfuscated hashes for uniqueness, following the format {@code HTHTHTHTHTHTHTHT.hpyhex.json}.</li>
+ *     <li>The {@link #read()} and {@link #write()} methods throw {@link IOException} if file operations
+ *         or JSON parsing fail, so proper exception handling is required.</li>
+ *     <li>Future versions will expand support for additional data formats beyond {@code hex.basic} and {@code hex}.</li>
+ * </ul>
+ *
+ * @author William Wu
+ * @version 1.2
+ * @since 1.2
+ */
 public class HexLogger {
     // Hashing
     /** Bit shift values used for the hashing obfuscation process. */

--- a/hexio/HexLogger.java
+++ b/hexio/HexLogger.java
@@ -417,6 +417,18 @@ public class HexLogger {
     }
 
     /**
+     * Erase the game data in this logger by reset them. This will not reset the file it points to or the player.
+     * This is almost equal to create another logger.
+     */
+    public void erase() {
+        currentEngine = new HexEngine(1, java.awt.Color.BLACK, java.awt.Color.WHITE);
+        currentQueue = new Piece[0];
+        moveOrigins = new ArrayList<Hex>();
+        movePieces = new ArrayList<Piece>();
+        completed = false;
+    }
+
+    /**
      * Deletes the file related to this {@code HexLogger} if exists
      *
      * @return true if the file is deleted, false otherwise
@@ -698,6 +710,8 @@ public class HexLogger {
         try{
             JsonArray movesJson = jsonObject.getJsonArray("moves");
             int movesSize = movesJson.size();
+            moveOrigins = new ArrayList<>(movesSize);
+            movePieces = new ArrayList<>(movesSize);
             // Populate moves
             for (int i = 0; i < movesSize; i ++){
                 try {

--- a/hexio/HexLogger.java
+++ b/hexio/HexLogger.java
@@ -476,7 +476,7 @@ public class HexLogger {
             // Populate queue
             for (int i = 0; i < queueSize; i ++){
                 try {
-                    JsonObject pieceJson = queueJson.getJsonObject(i);
+                    JsonArray pieceJson = queueJson.getJsonArray(i);
                     currentQueue[i] = HexConverter.convertPiece(pieceJson);
                 } catch (Exception e) {
                     throw new IOException("Fail to read piece at index " + i + " in game queue");
@@ -506,13 +506,13 @@ public class HexLogger {
                     // Record move
                     Hex moveOrigin; Piece movePiece;
                     try {
-                        JsonObject moveOriginJson = movesJson.getJsonObject(i);
+                        JsonObject moveOriginJson = moveJson.getJsonObject("center");
                         moveOrigin = HexConverter.convertHex(moveOriginJson);
                     } catch (Exception e) {
                         throw new IOException("Fail to read move at index " + i + " in game moves due to failed center conversion");
                     }
                     try {
-                        JsonObject movePieceJson = movesJson.getJsonObject(i);
+                        JsonArray movePieceJson = moveJson.getJsonArray("piece");
                         movePiece = HexConverter.convertPiece(movePieceJson);
                     } catch (Exception e) {
                         throw new IOException("Fail to read move at index " + i + " in game moves due to failed piece conversion");
@@ -525,6 +525,7 @@ public class HexLogger {
                 }
             }
         } catch (Exception e) {
+            if (e instanceof IOException) throw e;
             throw new IOException("Fail to read game moves");
         }
     }

--- a/hexio/HexLogger.java
+++ b/hexio/HexLogger.java
@@ -1,10 +1,13 @@
 package hexio;
 
 import hex.*;
+import io.*;
+
 import javax.json.*;
 import javax.json.stream.*;
 import java.io.File;
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.file.*;
 import java.time.*;
@@ -404,5 +407,61 @@ public class HexLogger {
         // write
         JsonObject resultingObject = jsonObjectBuilder.build();
         writeJsonToFile(resultingObject);
+    }
+
+    /**
+     * Reads the log file and parses it into memory.
+     * This populates the {@code engine}, {@code queue}, {@code moves}, and other game data from JSON.
+     * @throws IOException If reading or parsing fails or if the game type is unsupported.
+     */
+    public void read() throws IOException {
+        String jsonString = readJsonFile();
+        if (jsonString == null) {
+            throw new IOException("Failed to read JSON file because it is null");
+        }
+
+        JsonObject jsonObject;
+        try (JsonReader jsonReader = Json.createReader(new StringReader(jsonString))) {
+            jsonObject = jsonReader.readObject();
+        } catch (Exception e) {
+            throw new IOException("Failed to parse JSON file", e);
+        }
+
+        // Game Check
+        String game;
+        try {
+            game = jsonObject.getString("Game");
+        } catch (Exception e) {
+            throw new IOException("Game type is not found", e);
+        }
+        if (!"HappyHex".equals(game)) {
+            throw new IOException("Game type is not HappyHex");
+        }
+
+        // Read player
+        try{
+            playerID = Long.parseUnsignedLong(jsonObject.getString("PlayerID"), 16);
+        } catch (Exception e){
+            throw new IOException("Fail to read Player ID");
+        }
+        try{
+            player = jsonObject.getString("Player");
+        } catch (Exception e){
+            throw new IOException("Fail to read Player");
+        }
+
+        // Read completed (This support versions without completed)
+        try{
+            completed = jsonObject.getBoolean("completed");
+        } catch (Exception e){
+            try{
+                completed = jsonObject.getBoolean("Completed");
+            } catch (Exception ex){
+                completed = true;
+            }
+        }
+
+        // Read engine
+
     }
 }

--- a/hexio/HexLogger.java
+++ b/hexio/HexLogger.java
@@ -169,7 +169,6 @@ public class HexLogger {
     public String getDataFileName() {
         return dataFile;
     }
-
     /**
      * Gets the name of the current player.
      * @return the player's name
@@ -180,6 +179,11 @@ public class HexLogger {
      * @return the player’s ID
      */
     public long getPlayerID(){return playerID;}
+    /**
+     * Whether this game have been completed. If it is completed, the game data cannot be further modified.
+     * @return true if this game is completed
+     */
+    public boolean isCompleted(){return completed;}
     // Hashing
     /**
      * Generates a string representing the current date and time in a simple format.

--- a/hexio/HexLogger.java
+++ b/hexio/HexLogger.java
@@ -250,11 +250,11 @@ public class HexLogger {
     public String toString() {
         StringBuilder builder = new StringBuilder("GameLogger[type = HexLogger, path = ");
         builder.append(dataFile);
-        builder.append(", data = HexData[player = ");
+        builder.append(", player = ");
         builder.append(player);
         builder.append(", playerID = ");
         builder.append(playerID);
-        builder.append(", engine = ");
+        builder.append(", data = HexData[engine = ");
         builder.append(currentEngine);
         builder.append(", queue = {");
         if (currentQueue.length > 0){

--- a/hexio/HexLogger.java
+++ b/hexio/HexLogger.java
@@ -3,6 +3,7 @@ package hexio;
 import hex.*;
 import javax.json.*;
 import javax.json.stream.*;
+import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.*;
@@ -284,7 +285,16 @@ public class HexLogger {
      * @return The raw JSON content as a string, or {@code null} if not found.
      */
     private String readJsonFile(){
-        return null; // To be implemented
+        File file = new File(dataFile);
+        if (file.exists()) {
+            String result;
+            try{
+                result = new String(Files.readAllBytes(file.toPath()));
+            } catch (IOException e) {
+                return null;
+            }
+            return result;
+        } else return null;
     }
 
     /**

--- a/hexio/HexLogger.java
+++ b/hexio/HexLogger.java
@@ -483,6 +483,7 @@ public class HexLogger {
                 }
             }
         } catch (Exception e) {
+            if (e instanceof IOException) throw e;
             throw new IOException("Fail to read game queue");
         }
 
@@ -519,6 +520,7 @@ public class HexLogger {
                     moveOrigins.add(moveOrigin);
                     movePieces.add(movePiece);
                 } catch (Exception e) {
+                    if (e instanceof IOException) throw e;
                     throw new IOException("Fail to read move at index " + i + " in game moves");
                 }
             }

--- a/hexio/HexLogger.java
+++ b/hexio/HexLogger.java
@@ -24,7 +24,9 @@ import java.util.ArrayList;
  * <h3>Purpose</h3>
  * The primary purpose of {@code HexLogger} is to serve as a robust logging utility for the HappyHex game,
  * enabling developers to save game states to JSON files, read them back, and manage game data efficiently.
- * It is particularly useful for tracking player progress, debugging, and analyzing game sessions.
+ * It is particularly useful for tracking player progress, debugging, and analyzing game sessions. This
+ * also record player information, which means data could be used for reviewing. For machine learning, the
+ * logged data could be used for training, helping future developers to build advanced autoplay systems.
  * The class supports the {@code hex.basic} and {@code hex} (unnamed) data formats, with plans to
  * support additional formats in future releases.
  *
@@ -167,6 +169,17 @@ public class HexLogger {
     public String getDataFileName() {
         return dataFile;
     }
+
+    /**
+     * Gets the name of the current player.
+     * @return the player's name
+     */
+    public String getPlayer() {return player;}
+    /**
+     * Gets the ID (long) of the current player.
+     * @return the player’s ID
+     */
+    public long getPlayerID(){return playerID;}
     // Hashing
     /**
      * Generates a string representing the current date and time in a simple format.

--- a/tests/hex/PieceTest.java
+++ b/tests/hex/PieceTest.java
@@ -6,6 +6,7 @@ import hex.Piece;
 import hex.Block;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.awt.Color;
 
@@ -113,6 +114,20 @@ public class PieceTest {
     }
 
     @Test
+    void testGetState() {
+        Piece piece = new Piece(4, Color.RED);
+        piece.add(0, -1);
+        piece.add(-1, 0);
+        piece.add(1, 1);
+
+        assertFalse(piece.getState(0, 0), "Block state at (0,0) should be false");
+        assertTrue(piece.getState(0, -1), "Block state at (0,-1) should be true");
+        assertTrue(piece.getState(-1, 0), "Block state at (-1,0) should be true");
+        assertTrue(piece.getState(1, 1), "Block state at (1,1) should be true");
+        assertFalse(piece.getState(2, 0), "Block state at (2,0) should be false");
+    }
+
+    @Test
     void testGetBlockByIndex() {
         Piece piece = new Piece(2, Color.RED);
         piece.add(0, 0);
@@ -162,6 +177,16 @@ public class PieceTest {
 
         String expected = "{Piece: {I = 0, J = 0, K = 0}{I = 1, J = 0, K = 1}}";
         assertEquals(expected, piece.toString(), "toString output should match");
+    }
+
+    @Test
+    void testToByte() {
+        Piece piece = new Piece(3, Color.GREEN);
+        piece.add(1, 1);
+        piece.add(0, 0);
+        piece.add(0, 1);
+
+        assertEquals(piece.toByte(), 0b00001101, "toByte output should be 0b00001101");
     }
 
     @Test


### PR DESCRIPTION
Added ways to automatically read and resume unfinished games if they exist. The game data will the write to the existing game log .hpyhex.json file.

Specificity, this features the following changes:
- In `Piece`, added getState, a method that handles null blocks
- Added method to convert `Piece` to byte representations
- Added tests for newly added features in Piece
- Implemented readJsonFile, which convert a file to a `JsonObject`
- Implemented read, which use the `JsonObject` to populate the data fields in the `HexLogger`
- Standardized toString methods in `hex` package to use the same format
- Added data format tracking and architecture to enable the logger to read and write for different data formats
- Added getters, such as `getPlayer`, `getPlayerID`, and `isCompleted` in `HexLogger`
- Implemented method to erase logger data
- Added relevant javadoc for newly added methods and classes