### PR TITLE
Fix bug "Last queue in logs may not be accurate"

### DIFF
--- a/GUI/GameEssentials.java
+++ b/GUI/GameEssentials.java
@@ -426,9 +426,9 @@ public final class GameEssentials {
             System.out.println(GameTime.generateSimpleTime() + " LaunchLogger: JSON data not logged in logs.json because player has not completed the game.");
         }
         try {
-            if (complete) gameLogger.completeGame();
             gameLogger.setEngine(engine);
             gameLogger.setQueue(queue.getPieces());
+            if (complete) gameLogger.completeGame();
             gameLogger.write();
             gameLogger.write("hex.binary");
         } catch (IOException e) {


### PR DESCRIPTION
The bug occurs when `setEngine()` and `setQueue()` method calls to `gameLogger` had no effect if called after `completeGame()`, due to the logger becoming immutable once marked as completed. As a result, final game data was not recorded in the logs for completed games. The fix reorders the method calls to set the engine and queue before marking the logger as complete.

Fixes and closes #50