### PR TITLE
Add Drop or Drag in File

### DIFF
--- a/viewer/Viewer.java
+++ b/viewer/Viewer.java
@@ -25,6 +25,7 @@
 package viewer;
 
 import viewer.graphics.frame.ViewerGUI;
+import viewer.graphics.frame.DropInFileAdaptor;
 import viewer.logic.Controller;
 
 import javax.swing.ImageIcon;
@@ -33,6 +34,8 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Image;
 import java.awt.Taskbar;
+import java.awt.HeadlessException;
+import java.awt.dnd.DropTarget;
 import java.util.Objects;
 
 /**
@@ -78,6 +81,7 @@ public final class Viewer {
         frame.setBackground(Color.WHITE);
         frame.add(new ViewerGUI(controller));
         parseArgs(args);
+        initDropTarget(frame);
         frame.setVisible(true);
     }
     /**
@@ -115,5 +119,19 @@ public final class Viewer {
             filename = filename.substring(0, filename.length() - 7);
         }
         controller.onFileChosen(filename);
+    }
+    /**
+     * Initializes the drop target for the main frame to allow file dropping.
+     * If the environment does not support file dropping, it catches the exception and ignores it.
+     *
+     * @param frame the main frame of the viewer
+     */
+    private static void initDropTarget(JFrame frame){
+        try {
+            DropTarget dropTarget = new DropTarget(frame, new DropInFileAdaptor(controller));
+            frame.setDropTarget(dropTarget);
+        } catch (HeadlessException ignored) {
+            // If the environment does not support file dropping, GameViewers disable this feature.
+        }
     }
 }

--- a/viewer/graphics/frame/DropInFileAdaptor.java
+++ b/viewer/graphics/frame/DropInFileAdaptor.java
@@ -1,0 +1,94 @@
+/*
+  MIT License
+
+  Copyright (c) 2025 William Wu
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+ */
+
+package viewer.graphics.frame;
+
+import viewer.logic.Controller;
+
+import java.awt.datatransfer.DataFlavor;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDropEvent;
+import java.io.File;
+import java.util.List;
+
+/**
+ * The {@code DropInFileAdaptor} class is a custom drop target adapter that handles file drop events
+ * in a GUI component, specifically designed for the HappyHex game viewer.
+ * <p>
+ * It accepts files dropped onto the component, checks if the file is a valid game file,
+ * and notifies the controller with the file path if valid.
+ * <p>
+ * This class extends {@link DropTargetAdapter} to provide custom behavior for handling file drops.
+ *
+ * @see DropTargetAdapter
+ * @see Controller#onFileChosen(String)
+ * @author William Wu
+ * @version 1.1 (HappyHex 1.4)
+ * @since 1.1 (HappyHex 1.4)
+ */
+public class DropInFileAdaptor extends DropTargetAdapter{
+    private final Controller controller;
+    /**
+     * Constructs a DropInFileAdaptor with the specified controller.
+     * <p>
+     * This adaptor is used to handle file drop events in a GUI component.
+     * It accepts files dropped onto the component, check if the file is a valid game file,
+     * and notifies the controller with the file path if valid.
+     *
+     * @param controller the controller to handle file drop events
+     */
+    public DropInFileAdaptor(Controller controller) {
+        super();
+        this.controller = controller;
+    }
+    /**
+     * Handles the drop event when files are dropped onto the component.
+     * <p>
+     * It accepts the drop, retrieves the list of dropped files, and checks if the first file
+     * is a valid game file (with a .hpyhex extension or without an extension). If valid,
+     * it notifies the controller with the file path to load the file.
+     *
+     * @param event the drop event containing information about the dropped files
+     */
+    @Override
+    public void drop(DropTargetDropEvent event) {
+        try {
+            event.acceptDrop(DnDConstants.ACTION_COPY);
+            Object droppedList = event.getTransferable().getTransferData(DataFlavor.javaFileListFlavor);
+            if (droppedList instanceof List) {
+                List<File> droppedFiles = (List<File>) droppedList;
+                if (!droppedFiles.isEmpty()){
+                    File file = droppedFiles.getFirst();
+                    String filename = file.getAbsolutePath();
+
+                    if (filename.endsWith(".hpyhex")) {
+                        filename = filename.substring(0, filename.length() - 7);
+                    }
+                    controller.onFileChosen(filename);
+                }
+            }
+        } catch (Exception ignored) {}
+    }
+}

--- a/viewer/logic/Controller.java
+++ b/viewer/logic/Controller.java
@@ -332,10 +332,6 @@ public class Controller{
      * @param filename the selected filename
      */
     public void onFileChosen(String filename) {
-        if (fileGui != null) {
-            fileGui.setFilename(filename);
-        }
-
         // Manipulate name
         String filePath = filename + ".hpyhex";
 
@@ -348,6 +344,9 @@ public class Controller{
             } catch (IOException ignored) {}
 
             if (loaded) {
+                if (fileGui != null) {
+                    fileGui.setFilename(filename);
+                }
                 try {
                     Tracker newTracker = new Tracker(logger); // create tracker takes time
                     synchronized (lock) {


### PR DESCRIPTION
Add feature for GameViewer to accept arbitrary binary or .hpyhex file in the .hpyhex format. This will update the filename and only display it if the file is loaded. Users may drop valid files to anywhere in the viewer window. For this feature to activate, the viewer must be running in an evironment that support direct file dropping. For this feature to succeed, it must use a version of hexio package that offer mutual support for absolute paths, and the 1.3.0-1.3.4 versions of hexio does exactly that. 